### PR TITLE
Fixed MyPy errors in upgrade-to-1 PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@ WARNING: 'jupyter_execute_notebooks' is deprecated for 'nb_execution_mode' [myst
 
 `nb_render_priority` has been removed and replaced by `nb_mime_priority_overrides`, which has a different format and is more flexible. See [Outputs MIME priority](docs/render/format_code_cells.md) for more information.
 
-As per the changes in [`myst_parser`](myst:develop/_changelog), the `dollarmath` syntax extension is no longer included by default.
+As per the changes in [`myst_parser`](inv:myst#develop/_changelog), the `dollarmath` syntax extension is no longer included by default.
 To re-add this extension, ensure that it is specified in your `conf.py`: `myst_enable_extensions = ["dollarmath"]`.
 
 For cell-level configuration the top-level key `render` has now been deprecated for `mystnb`.
@@ -168,7 +168,7 @@ See [Embedding outputs as variables](docs/render/glue.md) for more details.
   - `nbconvert`
 - Updated:
   - `Python`: `3.6+ -> 3.7+`
-  - `myst_parser`: [`0.15 -> 0.17`](myst:develop/_changelog)
+  - `myst_parser`: [`0.15 -> 0.17`](inv:myst#develop/_changelog)
   - `jupyter-cache`: [`0.4 -> 0.5`](https://github.com/executablebooks/jupyter-cache/blob/master/CHANGELOG.md)
   - `sphinx-togglebutton`: [`0.1 -> 0.3`](https://sphinx-togglebutton.readthedocs.io/en/latest/changelog.html)
 

--- a/docs/authoring/custom-formats.Rmd
+++ b/docs/authoring/custom-formats.Rmd
@@ -21,7 +21,7 @@ nb_custom_formats = {
 ```
 
 - The string should be a Python function that will be loaded by `import mylibrary.converter_function`
-- The function should take a file's contents (as a `str`) and return an [nbformat.NotebookNode](nbformat:api)
+- The function should take a file's contents (as a `str`) and return an [nbformat.NotebookNode](inv:nbformat#api)
 
 If the function takes additional keyword arguments, then you can specify these as dictionary in a second argument.
 For example this is what the default conversion would look like:

--- a/docs/authoring/jupyter-notebooks.md
+++ b/docs/authoring/jupyter-notebooks.md
@@ -16,13 +16,13 @@ Sphinx using the MyST parser.[^download]
 
 :::{seealso}
 For more information about what you can write with MyST Markdown, see the
-[MyST Parser documentation](myst:intro/get-started).
+[MyST Parser documentation](inv:myst#intro/get-started).
 :::
 
 ### Configuration
 
-The MyST-NB parser derives from [the base MyST-Parser](myst:intro/get-started), and so all the same configuration options are available.
-See the [MyST configuration options](myst:sphinx/config-options) for the full set of options, and [MyST syntax guide](myst:syntax/core) for all the syntax options.
+The MyST-NB parser derives from [the base MyST-Parser](inv:myst#intro/get-started), and so all the same configuration options are available.
+See the [MyST configuration options](inv:myst#sphinx/config-options) for the full set of options, and [MyST syntax guide](inv:myst#syntax/core) for all the syntax options.
 
 To build documentation from this notebook, the following options are set:
 
@@ -38,7 +38,7 @@ myst_url_schemes = ("http", "https", "mailto")
 ```
 
 :::{note}
-Loading the `myst_nb` extension also activates the [`myst_parser`](myst:index) extension, for enabling the MyST flavour of Markdown.
+Loading the `myst_nb` extension also activates the [`myst_parser`](inv:myst#index) extension, for enabling the MyST flavour of Markdown.
 It is not required to add this explicitly in the list of `extensions`.
 :::
 
@@ -53,7 +53,7 @@ For example, here's the MyST-NB logo:
 
 ![myst-nb logo](../_static/logo-wide.svg)
 
-By adding `"html_image"` to the `myst_enable_extensions` list in the sphinx configuration ([see here](myst:syntax/images)), you can even add HTML `img` tags with attributes:
+By adding `"html_image"` to the `myst_enable_extensions` list in the sphinx configuration ([see here](inv:myst#syntax/images)), you can even add HTML `img` tags with attributes:
 
 ```html
 <img src="../_static/logo-wide.svg" alt="logo" width="200px" class="shadow mb-2">
@@ -66,7 +66,7 @@ For example, here's a note admonition block:
 
 :::::{note}
 **Wow**, a note!
-It was generated with this code ([as explained here](myst:syntax/admonitions)):
+It was generated with this code ([as explained here](inv:myst:std:label#syntax/admonitions)):
 
 ````md
 :::{note}
@@ -77,7 +77,7 @@ It was generated with this code ([as explained here](myst:syntax/admonitions)):
 :::::
 
 If you wish to use "bare" LaTeX equations, then you should add `"amsmath"` to the `myst_enable_extensions` list in the sphinx configuration.
-This is [explained here](myst:syntax/amsmath), and works as such:
+This is [explained here](inv:myst:std:label#syntax/amsmath), and works as such:
 
 ```latex
 \begin{equation}
@@ -110,7 +110,7 @@ $$e^{i\pi} + 1 = 0$$ (euler)
 Euler's identity, equation {math:numref}`euler`, was elected one of the
 most beautiful mathematical formulas.
 
-You can see the syntax used for this example [here in the MyST documentation](myst:syntax/math).
+You can see the syntax used for this example [here in the MyST documentation](inv:myst:std:label#syntax/math).
 
 ## Code cells and outputs
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,7 +86,7 @@ Build single or collections of documents into multiple formats (HTML, PDF, ...).
 
 MyST-NB is a module within the [Executable Books Project](https://executablebooks.org),
 an international collaboration to build open source tools that facilitate publishing computational narratives using the Jupyter ecosystem.
-It is also a core component of [Jupyter Book](jb:intro).
+It is also a core component of [Jupyter Book](inv:jb#intro).
 
 Check out the [Gallery of Jupyter Books](https://executablebooks.org/en/latest/gallery),
 for inspiration from across the community.


### PR DESCRIPTION
Hi @aleivag! Thanks for the work you're doing on upgrading MyST-NB to MyST Parser 1.0.0 - I am sneakily using your branch in some of my docs and it seems to work! I noticed that your PR had stalled, and I have some knowledge about Python's typing system so I thought I'd chip in. Hence this PR to your PR!

I hope you don't feel like I'm stepping on your toes - I haven't contributed to MyST before, so I don't really have any special knowledge about what the maintainers will like. So I thought I'd send this to you rather than directly to MyST NB - if you think this is no good, no worries :)

I experimented with a few solutions to the `create_warnings` problem, and eventually settled on this one. It just adds a check to your implementation of `create_warnings` so that it can accept warning enums from either package, and then changes calls to `self.create_warnings(...)` in `render.py` to `create_warnings(self.document, ...)`. This way the underlying MyST Parser code doesn't ever see the MyST NB warnings, and the MyST NB code can accept either type. It's also a very minimal change that will continue to work as expected into the future, and it reduces the weirdness of relying on a child class to implement a method you need without declaring it abstract... but now we're getting into advantages that probably only I care about.

I experimented with adding a similarly polymorphic `create_warning` method to the `MditRenderMixin` class, but that doesn't work (as you probably know) because it is overwritten by child classes. I also tried to just make `MySTNBWarnings` a subclass of `MySTWarnings`, but TIL that python Enums can't do that (which I guess makes sense). I think the solution in this PR is as good as it's going to get - it's frustrating that MyST Parser didn't think about how downstream packages would want to extend the warning system!

I also updated `myst_nb/core/config.py` to work with the new warnings system, which also included adding a few new variants to your warnings enum. Tests pass locally (except for docutils.py, which I couldn't get to run), and all the pre-commit stuff is passing!

A lot of the line changes are from adding the `__future__` import to `config.py` to match the other modules... PyUpgrade did a lot of stuff automatically. I'm happy to revert that change if it's too much noise!

Hope this is useful! If you'd prefer I open a PR with MyST-NB directly, I'm happy to do that too - just wanted to make sure you have control over the work you've already done. And I'm happy to write some tests to get the coverage up if that ends up being a blocker, or to try and figure out why RTD is complaining.

Thanks!